### PR TITLE
Init human readable cog output

### DIFF
--- a/src/stores/cogCreate.ts
+++ b/src/stores/cogCreate.ts
@@ -1,4 +1,4 @@
-import { entityAttributesMap } from "@/utils/attributeUtils";
+import { entityAttributesMap, solveEquation } from "@/utils/attributeUtils";
 import {
   cogCreateOptionsValidator,
   type EntityAttribute,
@@ -22,7 +22,8 @@ import {
   totalAP,
   spentAP,
 } from "@/utils/copy/createCogLogic";
-import { renderMarkdown, editorEmpty } from "@/utils/textUtils";
+import { solveEquationsInText, editorEmpty } from "@/utils/textUtils";
+import { computed } from "vue";
 import { defineStore } from "pinia";
 import { useEntityStore } from "./entity";
 
@@ -76,7 +77,7 @@ export const useCogCreateStore = defineStore("cogCreate", {
       const allAbilities = entityAbilities(this.cogAbilities, this.options);
       const abilities = allAbilities.map(({ name, effect }) => ({ name, effect }));
       for (const ability of abilities) {
-        statBlock.push(`${ability.name}: ${renderMarkdown(ability.effect)}`); //FIXME I don't think renderMarkdown is what I'm looking for here
+        statBlock.push(`${ability.name}: ${solveEquationsInText(ability.effect, this.cogAttrs)}`);
       }
 
       //statBlock.push(JSON.stringify(this.collectedCog, null, 2)); //original JSON

--- a/src/stores/cogCreate.ts
+++ b/src/stores/cogCreate.ts
@@ -7,6 +7,7 @@ import {
   type UpdatedEntityAttributes,
   type CogCreateOptions,
 } from "@/utils/backendTypes";
+import { cogTypeOptions } from "@/utils/copy/createCogTypeOptions";
 import {
   cogBaseAttribute,
   cogAcc,
@@ -21,7 +22,7 @@ import {
   totalAP,
   spentAP,
 } from "@/utils/copy/createCogLogic";
-import { editorEmpty } from "@/utils/textUtils";
+import { renderMarkdown, editorEmpty } from "@/utils/textUtils";
 import { defineStore } from "pinia";
 import { useEntityStore } from "./entity";
 
@@ -54,6 +55,32 @@ export const useCogCreateStore = defineStore("cogCreate", {
     totalAP: (state) => totalAP(state.options),
     remainingAP(): number {
       return this.totalAP - spentAP(this.cogAbilities, this.options);
+    },
+    cogStatBlock(): string {
+      let statBlock = [];
+      statBlock.push(this.options.name);
+      const cogTypeName = cogTypeOptions[this.options.type].replace(/^\*\*(.*?)\*\*.*$/, '$1');
+      statBlock.push(`Level ${this.options.level} ${cogTypeName}`);
+      statBlock.push(`${this.options.desc.replace(/(<([^>]+)>)/gi, "")}`); //remove HTML tags because I don't know how to make this copyable code use rich formatting
+      const attributeString = Object.entries(this.collectedCog.entity.attributes)
+        .slice(0,9) //only first 9 attrs
+        .map(([key, value]) => `${key.toUpperCase()}: ${value}`).join(", ");
+      statBlock.push(attributeString);
+      statBlock.push(`Initiative: ${this.collectedCog.entity.attributes.init}`);
+      statBlock.push(`HP: ${this.collectedCog.entity.attributes.max_hp}`);
+      statBlock.push(`Armor: ${this.cogAttrs.armor?.val ?? 0}`);
+      statBlock.push(`Vim: ${this.collectedCog.entity.attributes.max_vim}`);
+      statBlock.push(`MP: ${this.collectedCog.entity.attributes.max_mp}`);
+      statBlock.push(`Speed: ${this.collectedCog.entity.attributes.speed}`);
+      statBlock.push(`Accuracy: ${this.collectedCog.entity.attributes.acc}`);
+      const allAbilities = entityAbilities(this.cogAbilities, this.options);
+      const abilities = allAbilities.map(({ name, effect }) => ({ name, effect }));
+      for (const ability of abilities) {
+        statBlock.push(`${ability.name}: ${renderMarkdown(ability.effect)}`); //FIXME I don't think renderMarkdown is what I'm looking for here
+      }
+
+      //statBlock.push(JSON.stringify(this.collectedCog, null, 2)); //original JSON
+      return statBlock.join("\n");
     },
     collectedCog(): UncompleteCollectedEntityWithChangelog {
       const text: UncompleteEntityText[] = [];

--- a/src/stores/cogCreate.ts
+++ b/src/stores/cogCreate.ts
@@ -77,7 +77,7 @@ export const useCogCreateStore = defineStore("cogCreate", {
       const allAbilities = entityAbilities(this.cogAbilities, this.options);
       const abilities = allAbilities.map(({ name, effect }) => ({ name, effect }));
       for (const ability of abilities) {
-        statBlock.push(`${ability.name}: ${solveEquationsInText(ability.effect, this.cogAttrs)}`);
+        statBlock.push(`${ability.name}: ${solveEquationsInText(ability.effect, this.cogAttrs)}`); //TODO replace [[X]] with how much X was spent for specific abilities
       }
 
       //statBlock.push(JSON.stringify(this.collectedCog, null, 2)); //original JSON

--- a/src/utils/textUtils.ts
+++ b/src/utils/textUtils.ts
@@ -108,7 +108,7 @@ const clearTemplateStrings = (text: string): string => {
   );
 };
 
-const solveEquationsInText = (
+export const solveEquationsInText = (
   text: string,
   attrs?: UpdatedEntityAttributes
 ): string => {

--- a/src/views/CreateNewCogView.vue
+++ b/src/views/CreateNewCogView.vue
@@ -108,7 +108,7 @@
           </ConfirmationModal>
         </div>
         <BaseCopyableCode
-          :text="JSON.stringify(cogCreateStore.collectedCog, null, 2)"
+          :text="cogCreateStore.cogStatBlock"
           class="mb-128"
         ></BaseCopyableCode>
       </form>


### PR DESCRIPTION
Replaces JSON copyable code output with human-readable output.
NYI: Replacing [[X]] in abilities with how much X was spent.
There might be details of the Cog that aren't included in the human-readable output? But I'm not sure what that would be, I think I included everything the GM needs to know about it.